### PR TITLE
Replay recording with discrete inputs + HDF5

### DIFF
--- a/csgo_hdf5_demo.py
+++ b/csgo_hdf5_demo.py
@@ -1,0 +1,151 @@
+import h5py
+import numpy as np
+import cv2
+import time
+import torch
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class CSGOAction:
+    keys: List[int]
+    mouse_x: float
+    mouse_y: float
+    l_click: bool
+    r_click: bool
+
+def decode_action_vector(y_preds):
+    # Constants from your config
+    N_KEYS = 11
+    N_CLICKS = 2
+    N_MOUSE_X = 23
+    N_MOUSE_Y = 15
+    MOUSE_X_POSSIBLES = [-1000, -500, -300, -200, -100, -60, -30, -20, -10, -4, -2, 0, 2, 4, 10, 20, 30, 60, 100, 200, 300, 500, 1000]
+    MOUSE_Y_POSSIBLES = [-200, -100, -50, -20, -10, -4, -2, 0, 2, 4, 10, 20, 50, 100, 200]
+
+    keys_pred = y_preds[0:N_KEYS]
+    l_click_pred = y_preds[N_KEYS:N_KEYS + 1]
+    r_click_pred = y_preds[N_KEYS + 1:N_KEYS + N_CLICKS]
+    mouse_x_pred = y_preds[N_KEYS + N_CLICKS:N_KEYS + N_CLICKS + N_MOUSE_X]
+    mouse_y_pred = y_preds[N_KEYS + N_CLICKS + N_MOUSE_X:N_KEYS + N_CLICKS + N_MOUSE_X + N_MOUSE_Y]
+
+    keys_pressed = []
+    keys_pressed_onehot = np.round(keys_pred)
+    key_map = ['W', 'A', 'S', 'D', 'SPACE', 'CTRL', 'SHIFT', '1', '2', '3', 'R']
+    
+    for i, pressed in enumerate(keys_pressed_onehot):
+        if pressed == 1:
+            keys_pressed.append(key_map[i])
+
+    l_click = bool(np.round(l_click_pred))
+    r_click = bool(np.round(r_click_pred))
+
+    mouse_x = MOUSE_X_POSSIBLES[np.argmax(mouse_x_pred)]
+    mouse_y = MOUSE_Y_POSSIBLES[np.argmax(mouse_y_pred)]
+
+    return CSGOAction(keys_pressed, mouse_x, mouse_y, l_click, r_click)
+
+def create_input_display(action, width=280, height=150, metadata=None):
+    # Create black background
+    display = np.zeros((height, width, 3), dtype=np.uint8)
+    
+    # Font settings
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    font_scale = 0.7
+    thickness = 2
+    color = (255, 255, 255)
+    
+    # Display metadata if available
+    y_pos = 30
+    if metadata:
+        cv2.putText(display, f"Resolution: {metadata['resolution']}", (10, y_pos), font, font_scale, color, thickness)
+        y_pos += 30
+        cv2.putText(display, f"Total Frames: {metadata['total_frames']}", (10, y_pos), font, font_scale, color, thickness)
+        y_pos += 30
+    
+    # Display keys
+    if action.keys:
+        cv2.putText(display, "Keys: " + " ".join(action.keys), (10, y_pos), font, font_scale, color, thickness)
+    
+    # Display mouse position
+    y_pos += 30
+    cv2.putText(display, f"Mouse: ({action.mouse_x}, {action.mouse_y})", (10, y_pos), font, font_scale, color, thickness)
+    
+    # Display clicks
+    y_pos += 30
+    clicks = []
+    if action.l_click:
+        clicks.append("LEFT")
+    if action.r_click:
+        clicks.append("RIGHT")
+    if clicks:
+        cv2.putText(display, "Clicks: " + " ".join(clicks), (10, y_pos), font, font_scale, color, thickness)
+    
+    return display
+
+def get_metadata(f):
+    # Count total frames by checking for frame_N_x keys
+    frame_count = 0
+    while f'frame_{frame_count}_x' in f:
+        frame_count += 1
+    
+    # Get resolution from first frame
+    first_frame = f['frame_0_x']
+    resolution = f'{first_frame.shape[1]}x{first_frame.shape[0]}'
+    
+    return {
+        'resolution': resolution,
+        'total_frames': frame_count
+    }
+
+def view_frames(filepath, num_frames=60, fps=16):
+    # Create windows
+    cv2.namedWindow('Game View', cv2.WINDOW_NORMAL)
+    cv2.namedWindow('Inputs', cv2.WINDOW_NORMAL)
+    
+    # Calculate frame display time
+    frame_time = 1.0 / fps
+    
+    with h5py.File(filepath, 'r') as f:
+        # Get metadata first
+        metadata = get_metadata(f)
+        print(f"Dataset Info:")
+        print(f"Resolution: {metadata['resolution']}")
+        print(f"Total Frames: {metadata['total_frames']}")
+        print(f"Playback FPS: {fps}")
+        
+        while True:  # Loop forever until user quits
+            for i in range(num_frames):
+                # Get frame data
+                frame_key = f'frame_{i}_x'
+                action_key = f'frame_{i}_y'
+                
+                if frame_key not in f or action_key not in f:
+                    break
+                    
+                # Load frame and convert from RGB to BGR for OpenCV
+                frame = f[frame_key][:]
+                frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                
+                # Load and decode action
+                action_vector = f[action_key][:]
+                action = decode_action_vector(action_vector)
+                
+                # Create input display with metadata
+                input_display = create_input_display(action, metadata=metadata)
+                
+                # Show frames
+                cv2.imshow('Game View', frame)
+                cv2.imshow('Inputs', input_display)
+                
+                # Wait for frame time and check for quit
+                key = cv2.waitKey(1)
+                if key == ord('q'):
+                    cv2.destroyAllWindows()
+                    return
+                    
+                time.sleep(frame_time)
+
+if __name__ == "__main__":
+    file_path = r"C:\Downloads\hdf5_dm_july2021_expert_100.hdf5"
+    view_frames(file_path, num_frames=1000, fps=16)

--- a/hdf5_process.py
+++ b/hdf5_process.py
@@ -1,0 +1,198 @@
+import subprocess
+import json
+import os
+import cv2
+import h5py
+import numpy as np
+import tempfile
+from pathlib import Path
+import shutil
+import time
+
+MELEE_ISO = r"C:\dummy\melee.iso"
+DOLPHIN_PATH = r"C:\dummy\dolphin.exe"
+FRAME_DUMP_PATH = r"C:\dummy\frames"
+DUMP_AVI_PATH = os.path.join(FRAME_DUMP_PATH, "framedump0.avi")
+
+def create_slippi_config(slp_path):
+    print(f"Creating Slippi config for {slp_path}")
+    config = {
+        "mode": "normal",
+        "replay": os.path.abspath(slp_path),
+        "isRealTimeMode": False,
+        "outputOverlayFiles": False,
+        "shouldAutomaticallyStop": True,
+        "gameEndDelay": 0
+    }
+
+    temp_config = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json')
+    json.dump(config, temp_config)
+    temp_config.close()
+    return temp_config.name
+
+def record_replay(slp_path):
+    print("\nStarting Dolphin recording...")
+    config_path = create_slippi_config(slp_path)
+
+    command = [
+        DOLPHIN_PATH,
+        f"--exec={MELEE_ISO}",
+        f"--slippi-input={config_path}",
+        "--batch",
+        "--hide-seekbar"
+    ]
+
+    print(f"Running command: {' '.join(command)}")
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Error running Dolphin: {e}")
+        raise
+    finally:
+        os.unlink(config_path)
+        print("Dolphin recording completed")
+
+def extract_frames(target_frames):
+    if not os.path.exists(DUMP_AVI_PATH):
+        raise FileNotFoundError(f"No AVI file found at {DUMP_AVI_PATH}")
+
+    print(f"\nExtracting frames from {DUMP_AVI_PATH}")
+    cap = cv2.VideoCapture(DUMP_AVI_PATH)
+
+    if not cap.isOpened():
+        raise RuntimeError("Failed to open AVI file")
+
+    frame_count = 0
+    frames = []
+    target_size = (96, 72)
+
+    while True:
+        ret, frame = cap.read()
+        if not ret or frame_count >= target_frames:
+            break
+
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frame = cv2.resize(frame, target_size, interpolation=cv2.INTER_AREA)
+        frames.append(frame)
+
+        frame_count += 1
+        if frame_count % 100 == 0:
+            print(f"Extracted {frame_count} frames...")
+
+    cap.release()
+    print(f"Extracted {frame_count} frames total")
+    return frames
+
+def read_game_data(json_path):
+    print(f"\nReading game data from {json_path}")
+    try:
+        with open(json_path, 'r') as f:
+            data = json.load(f)
+
+        p1_frames = data['players'][0]['frames']
+        p2_frames = data['players'][1]['frames']
+        last_frame = data['last_frame']
+
+        print(f"Found {len(p1_frames)} frames of player data")
+        print(f"Last frame in replay: {last_frame}")
+
+        if len(p1_frames) != len(p2_frames):
+            raise ValueError(f"Player frame counts don't match: P1={len(p1_frames)}, P2={len(p2_frames)}")
+
+        target_frames = max(len(p1_frames), last_frame)
+        print(f"Using target frame count: {target_frames}")
+
+        return p1_frames, p2_frames, target_frames
+
+    except (KeyError, IndexError) as e:
+        print(f"Error parsing JSON data: {e}")
+        raise
+
+def quantize_analog(value, num_buckets, input_min, input_max):
+    bucket_size = (input_max - input_min) / num_buckets
+    offset = bucket_size / 2
+    normalized = (value - input_min + offset) / (input_max - input_min)
+    bucket = int(np.clip(normalized * num_buckets - 0.5, 0, num_buckets - 1))
+
+    one_hot = np.zeros(num_buckets)
+    one_hot[bucket] = 1
+    return one_hot
+
+def create_action_vector(frame_data):
+    buttons = {
+        0x0001: 'D-LEFT',
+        0x0002: 'D-RIGHT',
+        0x0004: 'D-DOWN',
+        0x0008: 'D-UP',
+        0x0010: 'Z',
+        0x0020: 'R',
+        0x0040: 'L',
+        0x0100: 'A',
+        0x0200: 'B',
+        0x0400: 'Y',
+        0x0800: 'X',
+        0x1000: 'START'
+    }
+
+    button_vec = np.zeros(12)
+    button_value = frame_data['buttons']
+    for i, (bit, _) in enumerate(buttons.items()):
+        if button_value & bit:
+            button_vec[i] = 1
+
+    joy_x = quantize_analog(frame_data['joy_x'], 16, -1, 1)
+    joy_y = quantize_analog(frame_data['joy_y'], 16, -1, 1)
+    c_x = quantize_analog(frame_data['c_x'], 16, -0.9875, 0.9875)
+    c_y = quantize_analog(frame_data['c_y'], 16, -1, 1)
+    trigger = quantize_analog(frame_data['trigger'], 4, 0, 1)
+
+    return np.concatenate([
+        button_vec,
+        joy_x,
+        joy_y,
+        c_x,
+        c_y,
+        trigger
+    ])
+
+def create_hdf5(frames, p1_frames, p2_frames, output_path):
+    print(f"\nCreating HDF5 file: {output_path}")
+    max_frames = min(len(frames), len(p1_frames))
+
+    with h5py.File(output_path, 'w') as f:
+        f.attrs['num_frames'] = max_frames
+        f.attrs['frame_width'] = 96
+        f.attrs['frame_height'] = 72
+        f.attrs['action_dims'] = 80
+
+        for frame_idx in range(max_frames):
+            if frame_idx % 100 == 0:
+                print(f"Processing frame {frame_idx}/{max_frames}...")
+
+            f.create_dataset(f'frame_{frame_idx}_x', data=frames[frame_idx])
+            f.create_dataset(f'frame_{frame_idx}_p1_y', data=create_action_vector(p1_frames[frame_idx]))
+            f.create_dataset(f'frame_{frame_idx}_p2_y', data=create_action_vector(p2_frames[frame_idx]))
+
+def main(slp_path="./replays/sample.slp",
+         json_path="./replays/sample.json",
+         output_path="melee_data.hdf5"):
+
+    try:
+        p1_frames, p2_frames, target_frames = read_game_data(json_path)
+        print("\nRecording replay...")
+        record_replay(slp_path)
+        print("\nExtracting frames from recording...")
+        frames = extract_frames(target_frames)
+        print("\nCreating HDF5 dataset...")
+        create_hdf5(frames, p1_frames, p2_frames, output_path)
+        print(f"\nSuccessfully created dataset at {output_path}")
+
+    except Exception as e:
+        print(f"\nError during processing: {e}")
+        raise
+
+if __name__ == "__main__":
+    start_time = time.time()
+    main()
+    elapsed = time.time() - start_time
+    print(f"\nTotal processing time: {elapsed:.2f} seconds")

--- a/melee_hdf5_demo.py
+++ b/melee_hdf5_demo.py
@@ -1,0 +1,209 @@
+import h5py
+import numpy as np
+import cv2
+import time
+from dataclasses import dataclass
+from typing import List
+from collections import deque
+
+@dataclass
+class MeleeAction:
+    buttons: List[str]
+    joy_x: float
+    joy_y: float
+    c_x: float
+    c_y: float
+    trigger: float
+
+def decode_melee_vector(y_preds):
+    """Decode the 80-dimensional action vector"""
+    # Constants 
+    N_BUTTONS = 12
+    N_ANALOG = 16
+    N_TRIGGER = 4
+
+    # Button mapping
+    BUTTON_MAP = [
+        'D-LEFT', 'D-RIGHT', 'D-DOWN', 'D-UP',
+        'Z', 'R', 'L', 'A', 'B', 'Y', 'X', 'START'
+    ]
+
+    # Split vector into components
+    buttons = y_preds[:N_BUTTONS]
+    joy_x = y_preds[N_BUTTONS:N_BUTTONS + N_ANALOG]
+    joy_y = y_preds[N_BUTTONS + N_ANALOG:N_BUTTONS + 2*N_ANALOG]
+    c_x = y_preds[N_BUTTONS + 2*N_ANALOG:N_BUTTONS + 3*N_ANALOG]
+    c_y = y_preds[N_BUTTONS + 3*N_ANALOG:N_BUTTONS + 4*N_ANALOG]
+    trigger = y_preds[N_BUTTONS + 4*N_ANALOG:]
+
+    # Decode buttons
+    pressed_buttons = []
+    for i, pressed in enumerate(buttons):
+        if pressed > 0.5:
+            pressed_buttons.append(BUTTON_MAP[i])
+
+    # Decode analog values (convert one-hot back to value)
+    def decode_analog(one_hot, min_val, max_val):
+        bucket = np.argmax(one_hot)
+        return min_val + (max_val - min_val) * (bucket / (len(one_hot) - 1))
+
+    return MeleeAction(
+        buttons=pressed_buttons,
+        joy_x=decode_analog(joy_x, -1, 1),
+        joy_y=decode_analog(joy_y, -1, 1),
+        c_x=decode_analog(c_x, -0.9875, 0.9875),
+        c_y=decode_analog(c_y, -1, 1),
+        trigger=decode_analog(trigger, 0, 1)
+    )
+
+def create_input_display(action, player_num=1, width=280, height=200, fps=None):
+    """Create visualization of Melee inputs"""
+    display = np.zeros((height, width, 3), dtype=np.uint8)
+    
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    font_scale = 0.6
+    thickness = 1
+    color = (255, 255, 255)
+    
+    # Title
+    y_pos = 25
+    cv2.putText(display, f"Player {player_num}", (10, y_pos), font, font_scale, color, thickness)
+    
+    # FPS Display
+    if fps is not None:
+        fps_text = f"FPS: {fps:.1f}"
+        cv2.putText(display, fps_text, (width - 100, y_pos), font, font_scale, color, thickness)
+    
+    # Buttons
+    y_pos += 25
+    if action.buttons:
+        # Split into multiple lines if too many buttons
+        button_text = " ".join(action.buttons)
+        if len(button_text) > 30:
+            chunks = [action.buttons[i:i+3] for i in range(0, len(action.buttons), 3)]
+            for chunk in chunks:
+                cv2.putText(display, " ".join(chunk), (10, y_pos), font, font_scale, color, thickness)
+                y_pos += 20
+        else:
+            cv2.putText(display, button_text, (10, y_pos), font, font_scale, color, thickness)
+            y_pos += 25
+    
+    # Analog stick positions
+    y_pos += 10
+    cv2.putText(display, f"Main: ({action.joy_x:.2f}, {action.joy_y:.2f})", 
+                (10, y_pos), font, font_scale, color, thickness)
+    
+    y_pos += 25
+    cv2.putText(display, f"C-Stick: ({action.c_x:.2f}, {action.c_y:.2f})", 
+                (10, y_pos), font, font_scale, color, thickness)
+    
+    # Trigger
+    y_pos += 25
+    cv2.putText(display, f"Trigger: {action.trigger:.2f}", 
+                (10, y_pos), font, font_scale, color, thickness)
+    
+    return display
+
+def get_metadata(f):
+    frame_count = 0
+    while True:
+        if f'frame_{frame_count}_x' not in f:
+            break
+        frame_count += 1
+    
+    first_frame = f['frame_0_x']
+    resolution = f'{first_frame.shape[1]}x{first_frame.shape[0]}'
+    
+    return {
+        'resolution': resolution,
+        'total_frames': frame_count
+    }
+
+class FrameTimer:
+    def __init__(self, target_fps):
+        self.target_fps = target_fps
+        self.target_frame_time = 1.0 / target_fps
+        self.last_frame_time = time.perf_counter()
+        self.frame_times = deque(maxlen=60)  # Store last 60 frame times for FPS calculation
+        
+    def wait_for_next_frame(self):
+        current_time = time.perf_counter()
+        elapsed = current_time - self.last_frame_time
+        
+        # If we're running behind, don't wait
+        if elapsed < self.target_frame_time:
+            wait_time = self.target_frame_time - elapsed
+            target_wake = current_time + wait_time
+            
+            while time.perf_counter() < target_wake:
+                # Busy-wait for more precise timing
+                pass
+                
+        # Record frame time for FPS calculation
+        actual_frame_time = time.perf_counter() - self.last_frame_time
+        self.frame_times.append(actual_frame_time)
+        self.last_frame_time = time.perf_counter()
+        
+        # Calculate current FPS
+        if self.frame_times:
+            current_fps = len(self.frame_times) / sum(self.frame_times)
+            return current_fps
+        return self.target_fps
+
+def view_frames(filepath, target_fps=60):
+    cv2.namedWindow('Game View', cv2.WINDOW_NORMAL)
+    cv2.namedWindow('P1 Inputs', cv2.WINDOW_NORMAL)
+    cv2.namedWindow('P2 Inputs', cv2.WINDOW_NORMAL)
+    
+    timer = FrameTimer(target_fps)
+    
+    with h5py.File(filepath, 'r') as f:
+        metadata = get_metadata(f)
+        print(f"Dataset Info:")
+        print(f"Resolution: {metadata['resolution']}")
+        print(f"Total Frames: {metadata['total_frames']}")
+        
+        frame_idx = 0
+        
+        while frame_idx < metadata['total_frames']:
+            # Get frame data
+            frame_key = f'frame_{frame_idx}_x'
+            p1_action_key = f'frame_{frame_idx}_p1_y'
+            p2_action_key = f'frame_{frame_idx}_p2_y'
+            
+            # Load and display frame
+            frame = f[frame_key][:]
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+            cv2.imshow('Game View', frame)
+            
+            # Load and display P1 actions
+            p1_action_vector = f[p1_action_key][:]
+            p1_action = decode_melee_vector(p1_action_vector)
+            current_fps = timer.wait_for_next_frame()
+            p1_display = create_input_display(p1_action, player_num=1, fps=current_fps)
+            cv2.imshow('P1 Inputs', p1_display)
+            
+            # Load and display P2 actions
+            p2_action_vector = f[p2_action_key][:]
+            p2_action = decode_melee_vector(p2_action_vector)
+            p2_display = create_input_display(p2_action, player_num=2, fps=current_fps)
+            cv2.imshow('P2 Inputs', p2_display)
+            
+            # Add progress indicator
+            progress = (frame_idx + 1) / metadata['total_frames'] * 100
+            print(f"\rProgress: {progress:.1f}% (FPS: {current_fps:.1f})", end='')
+            
+            # Check for quit
+            key = cv2.waitKey(1)
+            if key == ord('q'):
+                print("\nPlayback stopped by user")
+                break
+            
+            frame_idx += 1
+        
+        print("\nPlayback complete")
+        cv2.destroyAllWindows()
+
+if __name__ == "__main__":
+    file_path = "melee_data.hdf5"
+    view_frames(file_path)  # Default 60fps


### PR DESCRIPTION
Analog input binning is done for both of the sticks and also the trigger.
16 values for the X and Y axises respectively on each stick; 4 values for the analog trigger.

This totals to a 80 dim input vector for one player, but 160 total (I plan to concatenate the two players in the actual training repository which means 1v1 multiplayer would work).

The Melee replay converter expects _both_ the sample .slp replay file itself and the .json converted variant for inputs (this conversion can be done using [slippc](https://github.com/pcrain/slippc), of which there is a compiled Windows version [here](https://github.com/jamorphy/latent-melee-data/releases/tag/slippc)).

Also, it requires you to have turned on frame dumping in Slippi Dolphin.

I've included basic demos for visualizing the HDF5 files (one for Melee, one for CS:GO).

![image](https://github.com/user-attachments/assets/2922a24a-6b00-4725-8efe-f814163973a1)

![image](https://github.com/user-attachments/assets/f1698d32-123c-4300-bd4e-c836039f0eff)

